### PR TITLE
fix: remove unused REPO variable from install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,6 @@ set -e
 set -o pipefail
 
 BIN_DIR="${TRUPOSITIVE_BIN_DIR:-$HOME/.local/bin}"
-REPO="trupositive-ai/trupositive"
 
 # Find binaries with validation
 REAL_TF=""


### PR DESCRIPTION
## Summary
- Removes the unused `REPO` variable from `install.sh` that was declared but never referenced, resolving ShellCheck warning SC2034.

Closes #4

## Test plan
- [ ] Run `shellcheck install.sh` and verify no SC2034 warning for `REPO`
- [ ] Run `bash -n install.sh` to confirm valid syntax
- [ ] Run the install script to confirm it still works correctly

Made with [Cursor](https://cursor.com)